### PR TITLE
Use backingNamespace of project when listing PRTB

### DIFF
--- a/internal/controller/clusters/cluster_controller.go
+++ b/internal/controller/clusters/cluster_controller.go
@@ -206,9 +206,14 @@ func (r *ClusterReconciler) SyncRancherRBAC(ctx context.Context, logger logr.Log
 		return fmt.Errorf("vCluster was installed in project [%[1]s] with UID [%[2]s]. Current project [%[1]s] has mismatched UID [%[3]s]", projectName, projectUID, project.GetUID())
 	}
 
-	projectRoleTemplateBindings, err := r.Client.List(ctx, gvk.ProjectRoleTemplateBindingManagementCattle, project.GetName())
+	prtbNamespace := project.GetName()
+	if backingNamespace := unstructured.GetNested[string](project.Object, "status", "backingNamespace"); backingNamespace != "" {
+		prtbNamespace = backingNamespace
+	}
+
+	projectRoleTemplateBindings, err := r.Client.List(ctx, gvk.ProjectRoleTemplateBindingManagementCattle, prtbNamespace)
 	if err != nil {
-		return fmt.Errorf("failed to list projectRoleTemplateBindings that target vCluster's project [%s]: %w", project.GetName(), err)
+		return fmt.Errorf("failed to list projectRoleTemplateBindings that target vCluster's project [%s] in namespace [%s]: %w", project.GetName(), prtbNamespace, err)
 	}
 
 	projectRoleTemplateBindings = unstructured.FilterItems[string](projectRoleTemplateBindings, fmt.Sprintf("%s:%s", project.GetNamespace(), project.GetName()), true, "projectName")


### PR DESCRIPTION
Prior, the namespace of project-scoped resources was assumed to be the same as the name of the project. Rancher added the backingNamespace field to fix the CVE CVE-2024-22031. If the operator was running in a setup using a version of rancher with the fix, it would search for PRTBs in the wrong namespace and find none. This would prevent project roles from the host cluster from being synced as the appropriate cluster role for the vCluster's rancher cluster. Now, if the backingNamespace field is available, it will be used to search for PRTBs.

Fixes ENG-9050