### PR TITLE
Use fixed retry interval if wait error

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: vcluster-rancher-operator
 description: Helm chart for vCluster Rancher Operator
 type: application
 
-version: "0.0.7"
+version: "0.0.9"
 

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -159,9 +159,12 @@ func (q *Handler) handleErr(err error, item Item) {
 	if isWaiting {
 		// log at info level - this is an expected condition during normal operation
 		q.logger.Info(err.Error()+", waiting...", "key", item.Key)
+		// successive retries are expected during wait; use a fixed retry interval over exponential backoff
+		q.queue.Forget(item)
+		q.queue.AddAfter(item, 5*time.Second)
 	} else {
 		// log actual errors at error level with stack trace for debugging
 		q.logger.Error(err, "error reconciling item, will retry", "key", item.Key)
+		q.queue.AddRateLimited(item)
 	}
-	q.queue.AddRateLimited(item)
 }


### PR DESCRIPTION
Wait error types communicate that we are waiting on a state change. We should constantly probe for that state change. Prior, exponential backoffs were applied to wait errors as that is how the queue works by default. Now, they will be retried after 5 seconds.

Fixes ENGPLAT-326